### PR TITLE
feat: 实现用户拉黑功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ scripts/check-dependencies/check-deps
 __pycache__/
 *.pyc
 *.pyo
+.worktrees

--- a/api/v1/admin/types.go
+++ b/api/v1/admin/types.go
@@ -29,6 +29,7 @@ type AdminUpdateUserRequest struct {
 	Phone         *string `json:"phone,omitempty" validate:"omitempty,e164"`
 	Role          *string `json:"role,omitempty" validate:"omitempty,oneof=reader author admin"`
 	Status        *string `json:"status,omitempty" validate:"omitempty"`
+	BanReason     *string `json:"banReason,omitempty" validate:"omitempty,max=500"`
 	EmailVerified *bool   `json:"email_verified,omitempty"`
 	PhoneVerified *bool   `json:"phone_verified,omitempty"`
 }

--- a/api/v1/admin/user_admin_api.go
+++ b/api/v1/admin/user_admin_api.go
@@ -139,7 +139,7 @@ func (api *UserAdminAPI) UpdateUserStatus(c *gin.Context) {
 
 	// 验证：封禁时必须提供原因
 	if status == users.UserStatusBanned && (req.BanReason == nil || *req.BanReason == "") {
-		response.BadRequest(c, "封禁用户时必须提供封禁原因")
+		response.BadRequest(c, "封禁用户时必须提供封禁原因", nil)
 		return
 	}
 
@@ -162,7 +162,7 @@ func (api *UserAdminAPI) UpdateUserStatus(c *gin.Context) {
 			return
 		}
 		if err == adminservice.ErrBanReasonRequired {
-			response.BadRequest(c, "封禁用户时必须提供封禁原因")
+			response.BadRequest(c, "封禁用户时必须提供封禁原因", nil)
 			return
 		}
 		c.Error(err)

--- a/models/admin/ban_record.go
+++ b/models/admin/ban_record.go
@@ -1,0 +1,28 @@
+package admin
+
+import (
+	"Qingyu_backend/models/shared"
+)
+
+// BanRecord 封禁记录模型
+// 用于记录用户的封禁/解封历史，支持审计追踪
+type BanRecord struct {
+	shared.IdentifiedEntity `bson:",inline"`
+	shared.BaseEntity       `bson:",inline"`
+
+	UserID     string `bson:"user_id" json:"userId"`
+	Action     string `bson:"action" json:"action"`     // "ban" 或 "unban"
+	Reason     string `bson:"reason" json:"reason"`
+	OperatorID string `bson:"operator_id" json:"operatorId"`
+	BanDuration *int  `bson:"ban_duration,omitempty" json:"banDuration,omitempty"` // 封禁时长（天）
+}
+
+// IsBanAction 判断是否为封禁操作
+func (r *BanRecord) IsBanAction() bool {
+	return r.Action == "ban"
+}
+
+// IsUnbanAction 判断是否为解封操作
+func (r *BanRecord) IsUnbanAction() bool {
+	return r.Action == "unban"
+}

--- a/models/users/user.go
+++ b/models/users/user.go
@@ -38,6 +38,11 @@ type User struct {
 	Nickname string     `bson:"nickname,omitempty" json:"nickname,omitempty" validate:"max=50"`
 	Bio      string     `bson:"bio,omitempty" json:"bio,omitempty" validate:"max=500"`
 
+	// 封禁相关字段
+	BanReason  string     `bson:"ban_reason,omitempty" json:"banReason,omitempty"`        // 封禁原因
+	BannedAt   *time.Time `bson:"banned_at,omitempty" json:"bannedAt,omitempty"`           // 封禁时间
+	BannedBy   string     `bson:"banned_by,omitempty" json:"bannedBy,omitempty"`           // 封禁操作者ID
+
 	// 个人资料扩展字段
 	Gender   string     `bson:"gender,omitempty" json:"gender,omitempty" validate:"omitempty,oneof=male female other"` // 性别
 	Birthday *time.Time `bson:"birthday,omitempty" json:"birthday,omitempty"`                                         // 生日

--- a/repository/interfaces/admin/ban_record_repository.go
+++ b/repository/interfaces/admin/ban_record_repository.go
@@ -1,0 +1,19 @@
+package admin
+
+import (
+	"context"
+
+	"Qingyu_backend/models/admin"
+)
+
+// BanRecordRepository 封禁记录仓储接口
+type BanRecordRepository interface {
+	// Create 创建封禁记录
+	Create(ctx context.Context, record *admin.BanRecord) error
+
+	// GetByUserID 获取用户的封禁历史
+	GetByUserID(ctx context.Context, userID string, page, pageSize int) ([]*admin.BanRecord, int64, error)
+
+	// GetActiveBan 获取用户当前生效的封禁记录（最后一条ban操作）
+	GetActiveBan(ctx context.Context, userID string) (*admin.BanRecord, error)
+}

--- a/repository/mongodb/admin/ban_record_repository_impl.go
+++ b/repository/mongodb/admin/ban_record_repository_impl.go
@@ -1,0 +1,88 @@
+package admin
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"Qingyu_backend/models/admin"
+	adminrepo "Qingyu_backend/repository/interfaces/admin"
+	"Qingyu_backend/repository/mongodb/base"
+)
+
+// banRecordRepositoryImpl 封禁记录仓储实现
+type banRecordRepositoryImpl struct {
+	*base.BaseMongoRepository
+}
+
+// NewBanRecordRepository 创建封禁记录仓储实例
+func NewBanRecordRepository(db *mongo.Database) adminrepo.BanRecordRepository {
+	return &banRecordRepositoryImpl{
+		BaseMongoRepository: base.NewBaseMongoRepository(db, "ban_records"),
+	}
+}
+
+// Create 创建封禁记录
+func (r *banRecordRepositoryImpl) Create(ctx context.Context, record *admin.BanRecord) error {
+	record.ID = primitive.NewObjectID()
+	record.TouchForCreate()
+	return r.Create(ctx, record)
+}
+
+// GetByUserID 获取用户的封禁历史
+func (r *banRecordRepositoryImpl) GetByUserID(ctx context.Context, userID string, page, pageSize int) ([]*admin.BanRecord, int64, error) {
+	// 解析用户ID
+	userOID, err := r.ParseID(userID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// 构造查询条件
+	filter := bson.M{"user_id": userOID}
+
+	// 计算跳过数量
+	skip := int64((page - 1) * pageSize)
+	opts := options.Find().
+		SetSort(bson.M{"created_at": -1}).
+		SetSkip(skip).
+		SetLimit(int64(pageSize))
+
+	// 查询记录
+	var records []*admin.BanRecord
+	if err := r.Find(ctx, filter, &records, opts); err != nil {
+		return nil, 0, err
+	}
+
+	// 统计总数
+	total, err := r.Count(ctx, filter)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return records, total, nil
+}
+
+// GetActiveBan 获取用户当前生效的封禁记录
+func (r *banRecordRepositoryImpl) GetActiveBan(ctx context.Context, userID string) (*admin.BanRecord, error) {
+	userOID, err := r.ParseID(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := bson.M{
+		"user_id": userOID,
+		"action":  "ban",
+	}
+
+	opts := options.FindOne().SetSort(bson.M{"created_at": -1})
+
+	var record admin.BanRecord
+	if err := r.FindOne(ctx, filter, &record, opts); err != nil {
+		return nil, err
+	}
+
+	return &record, nil
+}

--- a/router/enter.go
+++ b/router/enter.go
@@ -38,12 +38,12 @@ import (
 	sharedStorage "Qingyu_backend/service/shared/storage"
 
 	versionAPI "Qingyu_backend/api/v1"
-	"Qingyu_backend/config"
 	financeApi "Qingyu_backend/api/v1/finance"
 	messagesApi "Qingyu_backend/api/v1/messages"
 	notificationsAPI "Qingyu_backend/api/v1/notifications"
 	recommendationAPI "Qingyu_backend/api/v1/recommendation"
 	socialApi "Qingyu_backend/api/v1/social"
+	"Qingyu_backend/config"
 	modelsMessaging "Qingyu_backend/models/messaging"
 	"Qingyu_backend/pkg/cache"
 	syncService "Qingyu_backend/pkg/sync"
@@ -600,9 +600,10 @@ func RegisterRoutes(r *gin.Engine) {
 	if mongoDB != nil {
 		// 创建用户管理仓储
 		userAdminRepo := adminrep.NewMongoUserAdminRepository(mongoDB)
+		banRecordRepo := adminrep.NewBanRecordRepository(mongoDB)
 
-		// 创建用户管理服务
-		userAdminSvc := adminservice.NewUserAdminService(userAdminRepo)
+		// 创建用户管理服务（带封禁记录）
+		userAdminSvc := adminservice.NewUserAdminServiceWithBanRepo(userAdminRepo, banRecordRepo)
 
 		// 创建权限管理仓储和服务
 		permissionRepo := authRep.NewMongoPermissionRepository(mongoDB)

--- a/service/admin/user_admin_service_ban_test.go
+++ b/service/admin/user_admin_service_ban_test.go
@@ -1,0 +1,200 @@
+package admin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	adminModel "Qingyu_backend/models/admin"
+	"Qingyu_backend/models/users"
+	adminrepo "Qingyu_backend/repository/interfaces/admin"
+)
+
+type stubUserAdminRepo struct {
+	getByIDFn func(ctx context.Context, userID primitive.ObjectID) (*users.User, error)
+	updateFn  func(ctx context.Context, userID primitive.ObjectID, user *users.User) error
+}
+
+func (s *stubUserAdminRepo) List(ctx context.Context, filter *adminrepo.UserFilter, page, pageSize int) ([]*users.User, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubUserAdminRepo) Create(ctx context.Context, user *users.User) error { return nil }
+func (s *stubUserAdminRepo) BatchCreate(ctx context.Context, usersList []*users.User) error {
+	return nil
+}
+func (s *stubUserAdminRepo) GetByID(ctx context.Context, userID primitive.ObjectID) (*users.User, error) {
+	if s.getByIDFn != nil {
+		return s.getByIDFn(ctx, userID)
+	}
+	return nil, ErrUserNotFound
+}
+func (s *stubUserAdminRepo) GetByEmail(ctx context.Context, email string) (*users.User, error) {
+	return nil, nil
+}
+func (s *stubUserAdminRepo) Update(ctx context.Context, userID primitive.ObjectID, user *users.User) error {
+	if s.updateFn != nil {
+		return s.updateFn(ctx, userID, user)
+	}
+	return nil
+}
+func (s *stubUserAdminRepo) UpdateStatus(ctx context.Context, userID primitive.ObjectID, status users.UserStatus) error {
+	return nil
+}
+func (s *stubUserAdminRepo) Delete(ctx context.Context, userID primitive.ObjectID) error { return nil }
+func (s *stubUserAdminRepo) HardDelete(ctx context.Context, userID primitive.ObjectID) error {
+	return nil
+}
+func (s *stubUserAdminRepo) GetActivities(ctx context.Context, userID primitive.ObjectID, page, pageSize int) ([]*users.UserActivity, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubUserAdminRepo) UpdateRoles(ctx context.Context, userID primitive.ObjectID, role string) error {
+	return nil
+}
+func (s *stubUserAdminRepo) GetStatistics(ctx context.Context, userID primitive.ObjectID) (*users.UserStatistics, error) {
+	return nil, nil
+}
+func (s *stubUserAdminRepo) ResetPassword(ctx context.Context, userID primitive.ObjectID, newPassword string) error {
+	return nil
+}
+func (s *stubUserAdminRepo) BatchUpdateStatus(ctx context.Context, userIDs []primitive.ObjectID, status users.UserStatus) error {
+	return nil
+}
+func (s *stubUserAdminRepo) BatchDelete(ctx context.Context, userIDs []primitive.ObjectID) error {
+	return nil
+}
+func (s *stubUserAdminRepo) GetUsersByRole(ctx context.Context, role string, page, pageSize int) ([]*users.User, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubUserAdminRepo) SearchUsers(ctx context.Context, keyword string, page, pageSize int) ([]*users.User, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubUserAdminRepo) CountByStatus(ctx context.Context) (map[string]int64, error) {
+	return nil, nil
+}
+func (s *stubUserAdminRepo) GetRecentUsers(ctx context.Context, limit int) ([]*users.User, error) {
+	return nil, nil
+}
+func (s *stubUserAdminRepo) GetActiveUsers(ctx context.Context, days int, limit int) ([]*users.User, error) {
+	return nil, nil
+}
+
+type stubBanRecordRepo struct {
+	createFn func(ctx context.Context, record *adminModel.BanRecord) error
+}
+
+func (s *stubBanRecordRepo) Create(ctx context.Context, record *adminModel.BanRecord) error {
+	if s.createFn != nil {
+		return s.createFn(ctx, record)
+	}
+	return nil
+}
+func (s *stubBanRecordRepo) GetByUserID(ctx context.Context, userID string, page, pageSize int) ([]*adminModel.BanRecord, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubBanRecordRepo) GetActiveBan(ctx context.Context, userID string) (*adminModel.BanRecord, error) {
+	return nil, nil
+}
+
+func TestUpdateUserStatusWithReason_BanRequiresReason(t *testing.T) {
+	repo := &stubUserAdminRepo{
+		getByIDFn: func(ctx context.Context, userID primitive.ObjectID) (*users.User, error) {
+			return &users.User{
+				Username: "u1",
+				Roles:    []string{"reader"},
+				Status:   users.UserStatusActive,
+			}, nil
+		},
+	}
+	svc := &UserAdminServiceImpl{userRepo: repo}
+
+	err := svc.UpdateUserStatusWithReason(context.Background(), primitive.NewObjectID().Hex(), users.UserStatusBanned, "admin1", nil)
+	assert.ErrorIs(t, err, ErrBanReasonRequired)
+}
+
+func TestUpdateUserStatusWithReason_BanSetsFieldsAndCreatesRecord(t *testing.T) {
+	var updated *users.User
+	var record *adminModel.BanRecord
+	reason := "恶意刷接口"
+
+	repo := &stubUserAdminRepo{
+		getByIDFn: func(ctx context.Context, userID primitive.ObjectID) (*users.User, error) {
+			return &users.User{
+				Username: "u1",
+				Roles:    []string{"reader"},
+				Status:   users.UserStatusActive,
+			}, nil
+		},
+		updateFn: func(ctx context.Context, userID primitive.ObjectID, user *users.User) error {
+			updated = user
+			return nil
+		},
+	}
+	banRepo := &stubBanRecordRepo{
+		createFn: func(ctx context.Context, r *adminModel.BanRecord) error {
+			record = r
+			return nil
+		},
+	}
+	svc := &UserAdminServiceImpl{userRepo: repo, banRecordRepo: banRepo}
+
+	err := svc.UpdateUserStatusWithReason(context.Background(), primitive.NewObjectID().Hex(), users.UserStatusBanned, "admin1", &reason)
+	assert.NoError(t, err)
+	if assert.NotNil(t, updated) {
+		assert.Equal(t, users.UserStatusBanned, updated.Status)
+		assert.Equal(t, "admin1", updated.BannedBy)
+		assert.Equal(t, reason, updated.BanReason)
+		assert.NotNil(t, updated.BannedAt)
+	}
+	if assert.NotNil(t, record) {
+		assert.Equal(t, "ban", record.Action)
+		assert.Equal(t, reason, record.Reason)
+		assert.Equal(t, "admin1", record.OperatorID)
+	}
+}
+
+func TestUpdateUserStatusWithReason_UnbanClearsFieldsAndCreatesRecord(t *testing.T) {
+	var updated *users.User
+	var record *adminModel.BanRecord
+	now := time.Now()
+
+	repo := &stubUserAdminRepo{
+		getByIDFn: func(ctx context.Context, userID primitive.ObjectID) (*users.User, error) {
+			return &users.User{
+				Username:  "u1",
+				Roles:     []string{"reader"},
+				Status:    users.UserStatusBanned,
+				BannedAt:  &now,
+				BannedBy:  "admin0",
+				BanReason: "旧原因",
+			}, nil
+		},
+		updateFn: func(ctx context.Context, userID primitive.ObjectID, user *users.User) error {
+			updated = user
+			return nil
+		},
+	}
+	banRepo := &stubBanRecordRepo{
+		createFn: func(ctx context.Context, r *adminModel.BanRecord) error {
+			record = r
+			return nil
+		},
+	}
+	svc := &UserAdminServiceImpl{userRepo: repo, banRecordRepo: banRepo}
+
+	err := svc.UpdateUserStatusWithReason(context.Background(), primitive.NewObjectID().Hex(), users.UserStatusActive, "admin2", nil)
+	assert.NoError(t, err)
+	if assert.NotNil(t, updated) {
+		assert.Equal(t, users.UserStatusActive, updated.Status)
+		assert.Nil(t, updated.BannedAt)
+		assert.Equal(t, "", updated.BannedBy)
+		assert.Equal(t, "", updated.BanReason)
+	}
+	if assert.NotNil(t, record) {
+		assert.Equal(t, "unban", record.Action)
+		assert.Equal(t, "解除封禁", record.Reason)
+		assert.Equal(t, "admin2", record.OperatorID)
+	}
+}


### PR DESCRIPTION
## 功能概述

实现管理员封禁/解封用户功能，支持封禁原因记录和审计历史追踪。

## 变更内容

### 数据模型层
- 扩展 `User` 模型：添加 `BanReason`、`BannedAt`、`BannedBy` 字段
- 新建 `BanRecord` 模型：继承基类模型，用于审计追踪

### Repository层
- 新建 `BanRecordRepository` 接口
- 实现 `banRecordRepositoryImpl`：嵌入 `BaseMongoRepository` 基类

### Service层
- 新增 `UpdateUserStatusWithReason` 方法
- 新增 `ErrBanReasonRequired` 错误码
- 支持封禁/解封状态切换和历史记录

### API层
- 扩展 `UpdateUserStatusRequest`：添加 `BanReason` 字段
- 更新 `UpdateUserStatus` handler：封禁时验证原因必填

## API使用示例

```bash
# 封禁用户
PUT /api/v1/admin/users/{userID}/status
{
  "status": "banned",
  "banReason": "违反社区规范"
}

# 解封用户
PUT /api/v1/admin/users/{userID}/status
{
  "status": "active"
}
```

## 测试建议

- [ ] 封禁用户时未提供原因应返回400错误
- [ ] 封禁成功后用户状态变为banned，封禁字段被设置
- [ ] 解封用户后封禁字段被清空
- [ ] 封禁/解封操作记录到BanRecord集合
- [ ] 不能封禁超级管理员

## 相关文档

已更新 `论文/figures/第5章代码截图附录.md`，添加图索引5.3.6和5.3.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)